### PR TITLE
Allow to specify the output file for backups

### DIFF
--- a/cozy_management/backup.py
+++ b/cozy_management/backup.py
@@ -21,26 +21,35 @@ def _get_couchdb_path():
     return database_dir[list(database_dir)[0]]
 
 
-def backup():
+def backup(backup_filename=None):
     '''
         Backup a Cozy
     '''
-    if not os.path.isdir(BACKUPS_PATH):
-        print 'Need to create {}'.format(BACKUPS_PATH)
-        os.makedirs(BACKUPS_PATH, 0700)
+    timestamp = time.strftime("%Y-%m-%d-%H-%M-%S", time.gmtime())
+
+    if not backup_filename:
+        if not os.path.isdir(BACKUPS_PATH):
+            print 'Need to create {}'.format(BACKUPS_PATH)
+            os.makedirs(BACKUPS_PATH, 0700)
+        backup_filename = '{backups_path}/cozy-{timestamp}.tgz'.format(
+            backups_path=BACKUPS_PATH,
+            timestamp=timestamp
+        )
+    elif os.path.exists(backup_filename):
+        print 'Backup file already exists: {}'.format(backup_filename)
+        return
+
     couchdb_path = _get_couchdb_path()
 
-    timestamp = time.strftime("%Y-%m-%d-%H-%M-%S", time.gmtime())
-    cmd = 'tar cvzf {backups_path}/cozy-{timestamp}.tgz'
+    cmd = 'tar cvzf {backup_filename}'
     cmd += ' --exclude stack.token'
     cmd += ' --exclude couchdb.login'
     cmd += ' --exclude self-hosting.json'
     cmd += ' /etc/cozy /usr/local/var/cozy {couchdb_path}/cozy.couch'
-    cmd = cmd.format(backups_path=BACKUPS_PATH,
-                     timestamp=timestamp,
+    cmd = cmd.format(backup_filename=backup_filename,
                      couchdb_path=couchdb_path)
     helpers.cmd_exec(cmd, show_output=True)
-    print 'Backup file: {}/cozy-{}.tgz'.format(BACKUPS_PATH, timestamp)
+    print 'Backup file: {}'.format(backup_filename)
 
 
 def restore(backup_file):

--- a/cozy_management/cli.py
+++ b/cozy_management/cli.py
@@ -32,7 +32,7 @@ Usage:
     cozy_management wait_cozy_stack
     cozy_management check_lsb_codename
     cozy_management emulate_smtp [--bind <ip>] [--port <port>]
-    cozy_management backup
+    cozy_management backup [<backup_filename>]
     cozy_management restore <backup_filename>
     cozy_management install_weboob
     cozy_management update_weboob
@@ -236,7 +236,11 @@ def main():
         asyncore.loop()
 
     if arguments['backup']:
-        backup.backup()
+        if arguments['<backup_filename>']:
+            backup_filename = arguments['<backup_filename>']
+        else:
+            backup_filename = None
+        backup.backup(backup_filename)
 
     if arguments['restore']:
         backup.restore(arguments['<backup_filename>'])


### PR DESCRIPTION
Adds an optional backup file parameter to specify the file to save backups to. Closes #10.

I tried to keep code style coherent with the rest of the code, let me know if everything is not ok.
